### PR TITLE
gradle: Remove redundant File object construction

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -401,7 +401,7 @@ fun updateChangelog(version: String?, replaceFirst: Boolean) {
 }
 
 fun updateModuleChangelog(gitRef: String) {
-    File(File(File(File(projectDir, "module"), "updates"), "release"), "changelog.txt")
+    File(projectDir, "module/updates/release/changelog.txt")
         .writeText("The changelog can be found at: [`CHANGELOG.md`]($projectUrl/blob/$gitRef/CHANGELOG.md).\n")
 }
 


### PR DESCRIPTION
The `File` constructor normalizes slashes in the child path component anyway.